### PR TITLE
Add advance() method

### DIFF
--- a/lib/VoiceOver.d.ts
+++ b/lib/VoiceOver.d.ts
@@ -13,6 +13,13 @@ export declare class VoiceOver {
         role?: "button" | "link";
         tries?: number;
     }): Promise<void>;
+    advance({ target, steps, }: {
+        target?: {
+            text: string;
+            role: string;
+        };
+        steps?: number;
+    }): Promise<string>;
     seek({ text, role, tries, }: {
         text: string;
         role?: string;

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "voiceover": "bin/voiceover.js"
   },
   "scripts": {
-    "build": "tsc",
-    "prepublish": "yarn build",
+    "build": "rimraf lib && tsc",
     "test": "playwright test"
   },
   "repository": {
@@ -39,6 +38,7 @@
     "chai": "^4.3.4",
     "mocha": "^9.0.2",
     "playwright-webkit": "^1.20.1",
+    "rimraf": "^3.0.2",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5"
   },

--- a/src/VoiceOver.ts
+++ b/src/VoiceOver.ts
@@ -85,6 +85,39 @@ export class VoiceOver {
     }
   }
 
+  public async advance({
+    target,
+    steps = 1,
+  }: {
+    target?: {
+      text: string;
+      role: string;
+    };
+    steps?: number;
+  }): Promise<string> {
+    const { text, role } = target;
+    const phrases = [];
+    let match = false;
+    let count = 0;
+    const textRegex = new RegExp(text, "i");
+
+    while (count < steps && !match) {
+      await this.execute(moveRight);
+      const phrase = await this.lastPhrase();
+      phrases.push(phrase);
+
+      if (phrase.match(textRegex)) {
+        if (!role || phrase.startsWith(role) || phrase.endsWith(role)) {
+          match = true;
+        }
+      }
+
+      count++;
+    }
+
+    return phrases[phrases.length - 1];
+  }
+
   public async seek({
     text,
     role,

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -16,8 +16,11 @@ test.describe('twitter.com', () => {
 
       await voiceOver.rotor({ menu: "Window Spots", find: "conten" });
       await voiceOver.execute(startInteracting);
-      const output = await voiceOver.seek({ text: 'link More information...' });
-      expect(output).toContain('link More information...');
+      const output = await voiceOver.advance({
+        target: { text: "More information...", role: "link" },
+        steps: 5,
+      });
+      expect(output).toEqual("link More information...");
     } catch (error) {
       console.warn(error);
     } finally {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,7 +1585,7 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-rimraf@3.0.2:
+rimraf@3.0.2, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
- `advance` is more descriptive and correct than `seek`
- accepts arguments for `target` and `steps`

usage: 

```typescript
const output = await voiceOver.advance({
  target: { text: "More information...", role: "link" },
  steps: 5,
});
expect(output).toEqual("link More information...");
```